### PR TITLE
Changes for deployment and separate module and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Files to ignore by git.
+
+# Back-up files
+*~
+*.swp
+
+# Generic auto-generated build files
+*.pyc
+*.pyo
+
+# Specific auto-generated build files
+/.tox
+/__pycache__
+/build
+/UnifiedLog.egg-info
+/dist
+
+# Code review files
+/.review
+
+# Pycharm files
+/.idea
+
+# Test coverage files
+.coverage
+tests-coverage.txt

--- a/UnifiedLog/Lib.py
+++ b/UnifiedLog/Lib.py
@@ -35,19 +35,21 @@
 
 from __future__ import print_function
 from __future__ import unicode_literals
-from uuid import UUID
+
 import binascii
-import biplist
 import datetime
 import ipaddress
 import logging
-import lz4.block
 import os
 import re
 import struct
 import time
 
-__VERSION__ = '0.2'
+from uuid import UUID
+
+import biplist
+import lz4.block
+
 
 log = logging.getLogger('UNIFIED_LOG_READER_LIB')
 

--- a/UnifiedLog/__init__.py
+++ b/UnifiedLog/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+"""A parser for Unified logging .tracev3 files."""
+
+__version__ = '0.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pip >= 7.0.0
+biplist >= 1.0.3
+ipaddress ; python_version < '3.0'
+lz4 >= 0.10.0

--- a/scripts/UnifiedLogReader.py
+++ b/scripts/UnifiedLogReader.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
 # Unified log reader
 # Copyright (c) 2018  Yogesh Khatri <yogesh@swiftforensics.com> (@swiftforensics)
@@ -43,7 +44,9 @@ import os
 import sqlite3
 import sys
 import time
-import UnifiedLogLib
+
+from UnifiedLog import Lib as UnifiedLogLib
+
 
 log = logging.getLogger('UNIFIED_LOG_READER')
 UnifiedLogLib.log = log

--- a/scripts/tracev3_decompress.py
+++ b/scripts/tracev3_decompress.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # 
 # This script will produce a decompressed .tracev3 file for analysis.
 # Provide either a file or a folder as argument, it will decompress all .tracev3 
@@ -7,12 +8,14 @@
 # (c) Yogesh Khatri 2018
 #
 # Tested on Sierra, High Sierra and Mojave
-#
-import lz4.block
-import os
-import sys
+
 import binascii
+import os
 import struct
+import sys
+
+import lz4.block
+
 
 def DecompressFile(input_path, output_path):
     try:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Installation and deployment script."""
+
+import glob
+import os
+import sys
+
+try:
+  from setuptools import find_packages, setup
+except ImportError:
+  from distutils.core import find_packages, setup
+
+# Change PYTHONPATH to include UnifiedLog so that we can get the version.
+sys.path.insert(0, '.')
+
+import UnifiedLog  # pylint: disable=wrong-import-position
+
+
+unifiedlog_description = (
+    'A parser for Unified logging .tracev3 files.')
+
+unifiedlog_long_description = (
+    'A parser for Unified logging .tracev3 files.')
+
+setup(
+    name='UnifiedLog',
+    version=UnifiedLog.__version__,
+    description=unifiedlog_description,
+    long_description=unifiedlog_long_description,
+    license='MIT',
+    url='https://github.com/ydkhatri/UnifiedLogReader',
+    maintainer='Yogesh Khatri',
+    maintainer_email='yogesh@swiftforensics.com',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Environment :: Console',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+    ],
+    packages=find_packages('.', exclude=[
+        'tests', 'tests.*']),
+    package_dir={
+        'UnifiedLog': 'UnifiedLog'
+    },
+    scripts=glob.glob(os.path.join('scripts', '[A-Za-z]*.py')),
+    data_files=[
+        ('share/doc/UnifiedLog', [
+            'LICENSE.txt', 'README.md']),
+    ],
+)


### PR DESCRIPTION
Added `.gitignore` to ignore various files that don't need to be under version control.

Moved `UnifiedLogLib.py` to `UnifiedLog/Lib.py` and added `__init__.py` so we can work towards using it as a stand-alone Python module.

Changes to import order to separate stand library imports from third party imports.
See https://github.com/google/styleguide/blob/gh-pages/pyguide.md#313-imports-formatting for rationale

Moved version to `__init__.py` so module metadata is in a single location separate from the code.

Added `requirements.txt` for ease of installing dependencies, for future changes of adding CI tests.

Added shebang `#!/usr/bin/env python` and `x-bit` to scripts so they can run on multiple platforms without having to explicitly specify the Python interpreter first.

Added `setup.py` for deployment.
