### PR TITLE
Changes to address issues in Uuidtext.Parse and Dsc._ParseFileObject

### DIFF
--- a/UnifiedLog/dsc_file.py
+++ b/UnifiedLog/dsc_file.py
@@ -72,6 +72,7 @@ class Dsc(data_format.BinaryDataFormat):
         while len(self.uuid_entries) < num_uuid_entries:
             file_object.seek(uuid_entry_offset, os.SEEK_SET)
             uuid_entry_data = file_object.read(28)
+            uuid_entry_offset += 28
 
             v_off, size = struct.unpack("<II", uuid_entry_data[:8])
             uuid_object = uuid.UUID(bytes=uuid_entry_data[8:24])

--- a/UnifiedLog/uuidtext_file.py
+++ b/UnifiedLog/uuidtext_file.py
@@ -3,7 +3,9 @@
 
 from __future__ import unicode_literals
 
+import struct
 import os
+import posixpath
 
 from UnifiedLog import data_format
 from UnifiedLog import logger
@@ -13,57 +15,108 @@ class Uuidtext(data_format.BinaryDataFormat):
     '''Uuidtext file parser.'''
 
     def __init__(self, v_file, uuid):
+        '''Initializes an uuidtext file parser.
+
+        Args:
+          v_file (VirtualFile): a virtual file.
+          uuid (uuid.UUID): an UUID.
+        '''
         super(Uuidtext, self).__init__()
-        self.file = v_file
-        self.flag1 = 0
-        self.flag2 = 0
-        self.num_entries = 0
+        self._file = v_file
         self.entries = []   # [ [range_start_offset, data_offset, data_len], [..] , ..]
         self.library_path = ''
         self.library_name = ''
         self.Uuid = uuid
 
+    def _ParseFileObject(self, file_object):
+        '''Parses an uuidtext file-like object.
+
+        Args:
+          file_object (file): file-like object.
+
+        Returns:
+          bool: True if the uuidtext file-like object was successfully parsed,
+              False otherwise.
+
+        Raises:
+          IOError: if the uuidtext file cannot be parsed.
+          OSError: if the uuidtext file cannot be parsed.
+          struct.error: if the uuidtext file cannot be parsed.
+        '''
+        file_header_data = file_object.read(16)
+        if file_header_data[0:4] != b'\x99\x88\x77\x66':
+            signature_base16 = binascii.hexlify(file_header_data[0:4])
+            logger.info((
+                'Wrong signature in uuidtext file, got 0x{} instead of '
+                '0x99887766').format(signature_base16))
+            return False
+
+        # Note that the flag1 and flag2 are not used.
+        flag1, flag2, num_entries = struct.unpack(
+            "<III", file_header_data[4:16])
+
+        entries_data_size = 8 * num_entries
+        entries_data = file_object.read(entries_data_size)
+
+        entry_offset = 0
+        data_offset = 16 + entries_data_size
+        while len(self.entries) < num_entries:
+            entry_end_offset = entry_offset + 8
+            range_start_offset, data_len = struct.unpack(
+                "<II", entries_data[entry_offset:entry_end_offset])
+
+            entry_offset = entry_end_offset
+
+            self.entries.append([range_start_offset, data_offset, data_len])
+            data_offset += data_len
+
+        file_object.seek(data_offset, os.SEEK_SET)
+        library_path_data = file_object.read(1024)
+        self.library_path = self._ReadCString(library_path_data)
+        self.library_name = posixpath.basename(self.library_path)
+
+        return True
+
     def ReadFmtStringFromVirtualOffset(self, v_offset):
-        if not self.file.is_valid: return '<compose failure [UUID]>' # value returned by 'log' program if uuidtext is not found
-        if v_offset & 0x80000000: return '%s' # if highest bit is set
+        if not self._file.is_valid:
+            return '<compose failure [UUID]>' # value returned by 'log' program if uuidtext is not found
+
+        if v_offset & 0x80000000:
+            return '%s' # if highest bit is set
+
         for entry in self.entries:
             if (entry[0] <= v_offset) and ((entry[0] + entry[2]) > v_offset):
                 rel_offset = v_offset - entry[0]
-                f = self.file.file_pointer
+                f = self._file.file_pointer
                 f.seek(entry[1] + rel_offset)
                 buffer = f.read(entry[2] - rel_offset)
-                return ReadCString(buffer)
+                return self._ReadCString(buffer)
+
         #Not found
         logger.error('Invalid bounds 0x{:X} for {}'.format(v_offset, str(self.Uuid))) # This is error msg from 'log'
         return '<compose failure [UUID]>'
 
     def Parse(self):
-        '''Parse the uuidtext file, returns True/False'''
-        f = self.file.open()
-        if not f:
-            return False
-        try:
-            buffer = f.read(16) # header
-            if buffer[0:4] != b'\x99\x88\x77\x66':
-                logger.info('Wrong signature in uuidtext file, got 0x{} instead of 0x99887766'.format(binascii.hexlify(buffer[0:4])))
-                return False
-            self.flag1, self.flag2, self.num_entries = struct.unpack("<III", buffer[4:16])
-            # Read entry structures
-            buffer = f.read(8 * self.num_entries)
-            pos = 0
-            data_offset = 16 + (8 * self.num_entries)
-            for i in range(self.num_entries):
-                range_start_offset, data_len = struct.unpack("<II", buffer[pos:pos+8])
-                self.entries.append([range_start_offset, data_offset, data_len])
-                pos += 8
-                data_offset += data_len
-            # Read library path
-            f.seek(data_offset)
-            path_buffer = f.read(1024)
-            self.library_path = ReadCString(path_buffer)
-            self.library_name = posixpath.basename(self.library_path)
+        '''Parses a uuidtext file.
 
-        except:
+        self._file.is_valid is set to False if this method encounters issues
+        parsing the file.
+
+        Returns:
+          bool: True if the dsc file-like object was successfully parsed,
+              False otherwise.
+        '''
+        file_object = self._file.open()
+        if not file_object:
+          return False
+
+        try:
+            result = self._ParseFileObject(file_object)
+        except (IOError, OSError, struct.error):
             logger.exception('Uuidtext Parser error')
-            self.file.is_valid = False
-        return True
+            result = False
+
+        if not result:
+            self._file.is_valid = False
+
+        return result

--- a/tests/uuidtext_file.py
+++ b/tests/uuidtext_file.py
@@ -17,6 +17,23 @@ from tests import test_lib
 class UuidtextTest(test_lib.BaseTestCase):
     '''Tests for the uuidtext file parser.'''
 
+    def testParseFileObject(self):
+        '''Tests the _ParseFileObject function.'''
+        path = self._GetTestFilePath(['0D3C2953A33917B333DD8366AC25F2'])
+        file_entry = virtual_file.VirtualFile(path, filetype='uuidtext')
+
+        uuid_object = uuid.UUID('{220D3C29-53A3-3917-B333-DD8366AC25F2}')
+        test_file = uuidtext_file.Uuidtext(file_entry, uuid_object)
+
+        with open(path, 'rb') as file_object:
+          test_file._ParseFileObject(file_object)
+
+        self.assertEqual(len(test_file.entries), 0)
+        self.assertEqual(test_file.library_path, '/usr/libexec/lsd')
+        self.assertEqual(test_file.library_name, 'lsd')
+
+    # TODO: add tests for ReadFmtStringFromVirtualOffset
+
     def testParse(self):
         '''Tests the Parse function.'''
         path = self._GetTestFilePath(['0D3C2953A33917B333DD8366AC25F2'])
@@ -25,6 +42,10 @@ class UuidtextTest(test_lib.BaseTestCase):
         uuid_object = uuid.UUID('{220D3C29-53A3-3917-B333-DD8366AC25F2}')
         test_file = uuidtext_file.Uuidtext(file_entry, uuid_object)
         test_file.Parse()
+
+        self.assertEqual(len(test_file.entries), 0)
+        self.assertEqual(test_file.library_path, '/usr/libexec/lsd')
+        self.assertEqual(test_file.library_name, 'lsd')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Fixed missing uuid_entry_offset increment in Dsc._ParseFileObject method
* Changed usage of range by while loop in Uuidtext.Parse method
* Fixed missing import in Uuidtext class due to wide except statement in Uuidtext.Parse method
* Fixed calls to missing ReadCstring in Uuidtext class due to wide except statement in Uuidtext.Parse method
* Split `_ParseFileObject` from Parse method