### PR TITLE
modify so as to each log entry is written in one line with properly p…

### DIFF
--- a/scripts/UnifiedLogReader.py
+++ b/scripts/UnifiedLogReader.py
@@ -237,9 +237,9 @@ class FileOutputWriter(object):
             self._file_object = io.open(self._path, 'wt', encoding='utf-8')
             try:
                 if self._mode == 'TSV_ALL':
-                    self._file_object.write(self._HEADER_ALL)
+                    self._file_object.write(self._HEADER_ALL + '\n')
                 else:
-                    self._file_object.write(self._HEADER_DEFAULT)
+                    self._file_object.write(self._HEADER_DEFAULT + '\n')
             except (IOError, OSError):
                 logger.exception('Error writing to output file')
                 return False
@@ -274,7 +274,7 @@ class FileOutputWriter(object):
                     self._file_object.write((
                         '{}\t0x{:X}\t{}\t{}\t0x{:X}\t{}\t0x{:X}\t0x{:X}\t{}\t'
                         '{}\t{}\t({})\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t'
-                        '{}').format(
+                        '{}\n').format(
                             log[0], log[1], log[2], log[3], log[4], log[5],
                             log[6], log[7], log[8], log[9], log[10], log[11],
                             log[12], log[13], log[14], log[15], log[16],
@@ -292,9 +292,9 @@ class FileOutputWriter(object):
                     msg += log[22]
 
                     self._file_object.write((
-                        '{time:26} {li[4]:<#10x} {li[5]:11} {li[6]:<#20x} '
-                        '{li[8]:<6} {li[10]:<4} {message}').format(
-                            li=log, time=log[3], message=msg))
+                        '{time} {li[4]:<#10x} {li[5]:11} {li[6]:<#20x} '
+                        '{li[8]:<6} {li[10]:<4} {message}\n').format(
+                            li=log, time=log[3], message=msg.replace('\n','')))
 
             except (IOError, OSError):
                 logger.exception('Error writing to output file')

--- a/scripts/UnifiedLogReader.py
+++ b/scripts/UnifiedLogReader.py
@@ -294,7 +294,7 @@ class FileOutputWriter(object):
                     self._file_object.write((
                         '{time} {li[4]:<#10x} {li[5]:11} {li[6]:<#20x} '
                         '{li[8]:<6} {li[10]:<4} {message}\n').format(
-                            li=log, time=log[3], message=msg.replace('\n','')))
+                            li=log, time=log[3], message=msg.replace('\n',',')))
 
             except (IOError, OSError):
                 logger.exception('Error writing to output file')


### PR DESCRIPTION
Hi Yogesh-san,

As far as I try the latest version of UnifiedLogReader in LOG_DEFAULT mode, the timestamp of each log entry is not properly written.
Also, I found the followings about the line break, both of which I believe are not what you originally intented.
* In LOG_DEFAULT, the first log entry starts right after the header without line break, and some log entries contain line breaks within themselves.
* In TSV_ALL, the header and all the log entries are written in one line.

I modified the code so as to eliminate the issues above, and if my modification seems OK to you, can you merge it to your branch?


Best regards,
Yuya Hashimoto
