### PR TITLE
Update setup.py to work with new version of pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pip >= 7.0.0
+pip >= 23.0.0
 biplist >= 1.0.3
 ipaddress
 lz4 >= 0.10.0

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,8 @@ try:
 except ImportError:
   from distutils.core import find_packages, setup
 
-try:  # for pip >= 10
-    from pip._internal.download import PipSession
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.download import PipSession
-    from pip.req import parse_requirements
+from pip._internal.network.session import PipSession
+from pip._internal.req.req_file import parse_requirements
 
 # Change PYTHONPATH to include UnifiedLog so that we can get the version.
 sys.path.insert(0, '.')
@@ -57,7 +53,7 @@ setup(
         ('share/doc/UnifiedLog', [
             'LICENSE.txt', 'README.md']),
     ],
-    install_requires=[str(req.req) for req in parse_requirements(
+    install_requires=[req.requirement for req in parse_requirements(
         'requirements.txt', session=PipSession(),
     )],
 )


### PR DESCRIPTION
Pip's module structure has changed significantly since v10.0. This PR fixes `setup.py` so that the pip import statements and references to `req` objects work. It also enforces pip v23.0 in the project so that `setup.py` doesn't need to deal with older versions of pip.